### PR TITLE
Added a fix to ensure an empty value is always submitted (like repeaters)

### DIFF
--- a/templates/bolt/editcontent/fields/_ajaxmultictselect.twig
+++ b/templates/bolt/editcontent/fields/_ajaxmultictselect.twig
@@ -85,7 +85,10 @@ sortable: field.sortable|default(false)
     'name': key,
     'field': field
     } %}
-
+    
+    {# This ensures that an empty value is always submitted #}
+    <input type="hidden" name="{{ buic_opt_select.name }}">
+    
     <div class="col-sm-9{{ option.sortable ? ' sortable-select2-container' }} js-ajax-multi-ct-select-container" data-field="{{ data_field|json_encode }}">
         {{ buic_select(buic_opt_select) }}
     </div>

--- a/web/ajax-multict-select-field.js
+++ b/web/ajax-multict-select-field.js
@@ -46,7 +46,7 @@
                         }
                     },
                     placeholder             : options.placeholder,
-                    allowClear              : options.allowClear,
+                    allowClear              : options.allowClear || true,
                     minimumResultsForSearch : options.minimumResultsForSearch,
                     width                   : options.width,
                     ajax                    : {


### PR DESCRIPTION
Previously, clearing of the AJAX multi-ct select field didn't save the result. This copies the same system as repeaters to make sure it saves!